### PR TITLE
feat: Deprecate support for strip_debug_* parameters. Introduce StripExtrasPostHook.

### DIFF
--- a/docs/hooks.md
+++ b/docs/hooks.md
@@ -36,7 +36,7 @@ A post hook will be provided with the raw content object, the incoming request,
 and the current response object. Post hooks can mutate the response object to
 provide additional headers etc. The CORS header implementation is done using a
 post hook. In the case the response format should be changed (if you have an
-xml api etc, the raw content can be reprocessed.)
+xml api etc, the raw content can be reprocessed.).
 
 ```python
 import starlette.applications
@@ -46,11 +46,11 @@ from starlette.requests import Request
 logger = logging.getLogger(__name__)
 
 
-def custom_hook(_content: dict, request: Request, response: Response) -> Response:
+def custom_hook(content: dict, request: Request, response: Response) -> Response:
     if "x-custom-header" in request.headers:
         response.headers["x-custom-response"] = "set"
 
-    return response
+    return content, response
 
 
 app = starlette.applications.Starlette()

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -54,19 +54,27 @@ add_exception_handler(
 )
 ```
 
-If you wish to hide debug messaging from external users, `strip_debug=True`
-will log the detail and remove it from the response.
+If you wish to hide debug messaging from external users, `StripExtrasPostHook`
+allows modifying the response content. `mandatory_fields` supports defining
+fields that should always be returned, default fields are `["type", "title",
+"status", "detail"]`.
 
-For more fine-grained control, `strip_debug_codes=[500, ...]` can be used to
-strip debug messaging from specific status codes. Allowing expected debug
-messages to reach the user, while suppressing unexpected server errors etc.
+For more fine-grained control, `exclude_status_codes=[500, ...]` can be used to
+allow extras for specific status codes. Allowing expected fields to reach the
+user, while suppressing unexpected server errors etc.
 
 ```python
 from starlette_problem.handler import add_exception_handler
 
 add_exception_handler(
     app,
-    strip_debug_dodes=[500],
+    post_hooks=[
+        StripExtrasPostHook(
+            mandatory_fields=["type", "title", "status", "detail", "custom-extra"],
+            exclude_status_codes=[400],
+            enabled=True,
+        )
+    ],
 )
 ```
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -116,6 +116,7 @@ ignore = [
     "ANN003",  # ParamSpec not available in 3.9
     "FIX",  # allow TODO
     "D",
+    "E501",  # handled by ruff format
 ]
 
 [tool.ruff.lint.per-file-ignores]

--- a/src/starlette_problem/handler.py
+++ b/src/starlette_problem/handler.py
@@ -73,7 +73,7 @@ class ExceptionHandler:
 
         if strip_debug is not None or strip_debug_codes is not None:
             warn(
-                "Using deprecated parameter 'strip_debug' or `strip_debug_codes`, switch to 'StripExtras' post hook.",
+                "Using deprecated parameter 'strip_debug' or `strip_debug_codes`, switch to 'StripExtrasPostHook'.",
                 FutureWarning,
                 stacklevel=2,
             )
@@ -192,7 +192,7 @@ class CorsPostHook:
         return content, response
 
 
-class StripExtras:
+class StripExtrasPostHook:
     def __init__(
         self: t.Self,
         logger: logging.Logger | None = None,

--- a/tests/test_handler.py
+++ b/tests/test_handler.py
@@ -127,7 +127,7 @@ class TestExceptionHandler:
         request = mock.Mock(headers={})
         exc = SomethingWrongError("something bad", a="b")
 
-        eh = handler.generate_handler(post_hooks=[handler.StripExtras()])
+        eh = handler.generate_handler(post_hooks=[handler.StripExtrasPostHook()])
         response = eh(request, exc)
 
         assert (
@@ -139,7 +139,7 @@ class TestExceptionHandler:
         request = mock.Mock(headers={})
         exc = SomethingWrongError("something bad", a="b")
 
-        eh = handler.generate_handler(post_hooks=[handler.StripExtras(enabled=True)])
+        eh = handler.generate_handler(post_hooks=[handler.StripExtrasPostHook(enabled=True)])
         response = eh(request, exc)
 
         assert (
@@ -151,7 +151,9 @@ class TestExceptionHandler:
         request = mock.Mock(headers={})
         exc = SomethingWrongError("something bad", a="b")
 
-        eh = handler.generate_handler(post_hooks=[handler.StripExtras(exclude_status_codes=[500], enabled=True)])
+        eh = handler.generate_handler(
+            post_hooks=[handler.StripExtrasPostHook(exclude_status_codes=[500], enabled=True)],
+        )
         response = eh(request, exc)
 
         assert (
@@ -164,7 +166,7 @@ class TestExceptionHandler:
         exc = SomethingWrongError("something bad", a="b")
 
         eh = handler.generate_handler(
-            post_hooks=[handler.StripExtras(mandatory_fields=["type", "title", "status", "a"], enabled=True)],
+            post_hooks=[handler.StripExtrasPostHook(mandatory_fields=["type", "title", "status", "a"], enabled=True)],
         )
         response = eh(request, exc)
 

--- a/tests/test_handler.py
+++ b/tests/test_handler.py
@@ -123,6 +123,53 @@ class TestExceptionHandler:
             "detail": "Something went bad",
         }
 
+    def test_strip_extras_post_hook_disabled(self):
+        request = mock.Mock(headers={})
+        exc = SomethingWrongError("something bad", a="b")
+
+        eh = handler.generate_handler(post_hooks=[handler.StripExtras()])
+        response = eh(request, exc)
+
+        assert (
+            response.body
+            == b'{"type":"something-wrong","title":"This is an error.","status":500,"a":"b","detail":"something bad"}'
+        )
+
+    def test_strip_extras_post_hook_enabled(self):
+        request = mock.Mock(headers={})
+        exc = SomethingWrongError("something bad", a="b")
+
+        eh = handler.generate_handler(post_hooks=[handler.StripExtras(enabled=True)])
+        response = eh(request, exc)
+
+        assert (
+            response.body
+            == b'{"type":"something-wrong","title":"This is an error.","status":500,"detail":"something bad"}'
+        )
+
+    def test_strip_extras_post_hook_exclude_status_code(self):
+        request = mock.Mock(headers={})
+        exc = SomethingWrongError("something bad", a="b")
+
+        eh = handler.generate_handler(post_hooks=[handler.StripExtras(exclude_status_codes=[500], enabled=True)])
+        response = eh(request, exc)
+
+        assert (
+            response.body
+            == b'{"type":"something-wrong","title":"This is an error.","status":500,"a":"b","detail":"something bad"}'
+        )
+
+    def test_strip_extras_post_hook_custom_mandatory(self):
+        request = mock.Mock(headers={})
+        exc = SomethingWrongError("something bad", a="b")
+
+        eh = handler.generate_handler(
+            post_hooks=[handler.StripExtras(mandatory_fields=["type", "title", "status", "a"], enabled=True)],
+        )
+        response = eh(request, exc)
+
+        assert response.body == b'{"type":"something-wrong","title":"This is an error.","status":500,"a":"b"}'
+
     def test_strip_debug(self):
         request = mock.Mock()
         exc = Exception("Something went bad")
@@ -431,7 +478,7 @@ async def test_exception_handler_in_app():
         },
     )
     transport = httpx.ASGITransport(app=app, raise_app_exceptions=False, client=("1.2.3.4", 123))
-    client = httpx.AsyncClient(transport=transport, app=app, base_url="https://test")
+    client = httpx.AsyncClient(transport=transport, base_url="https://test")
 
     r = await client.get("/endpoint")
     assert r.json() == {
@@ -455,7 +502,7 @@ async def test_exception_handler_in_app_post_register():
     )
 
     transport = httpx.ASGITransport(app=app, raise_app_exceptions=False, client=("1.2.3.4", 123))
-    client = httpx.AsyncClient(transport=transport, app=app, base_url="https://test")
+    client = httpx.AsyncClient(transport=transport, base_url="https://test")
 
     r = await client.get("/endpoint")
     assert r.json() == {


### PR DESCRIPTION
PostHook implementation has been modified to return the content and the response. As the hook can mutate the content.